### PR TITLE
encode with 'unicode-escape'

### DIFF
--- a/TwitterWebsiteSearch.py
+++ b/TwitterWebsiteSearch.py
@@ -241,7 +241,7 @@ def _parse_tweet_media(element, media):
 
 def parse_tweets(items_html):
     try:
-        html = lh.fromstring(items_html)
+        html = lh.fromstring(items_html.encode('unicode-escape'))
     except lxml.etree.ParserError as e:
         return []
     tweets = []


### PR DESCRIPTION
took me a while to figure out what was wrong, but the presence of an emoji will cause the lxml parser to flip out and throw a "Document is empty" and not parse the response at all. If this happens on the first fetch, the script wont really work. Thanks for this!
